### PR TITLE
Full node port forward check, check ipv4+ipv6 when ipv6 is available

### DIFF
--- a/configcheck.php
+++ b/configcheck.php
@@ -96,15 +96,11 @@
     <div class="panel-heading"><b>Full Node port forward</b></div>
     <div class="panel-body" id="portforward">
 		<?php
-		//Check if the port is open using guldennode.com
-		$openportcheck = file_get_contents("https://guldennodes.com/portcheck/?json");
-		$openportreturn = json_decode($openportcheck, true);
-		
-		if($openportreturn['success']) {
-		  	echo $openportreturn['success'];
-		  } elseif($openportreturn['error']) {
-		  	echo $openportreturn['error'];
-		  }
+			$checks = fullNodeCheck();
+			
+			foreach ($checks as $check) {
+				echo $check . "<br />";
+			}
 		?>
     </div>
   </div>

--- a/lib/functions/functions.php
+++ b/lib/functions/functions.php
@@ -214,8 +214,40 @@ function selectElementWithValue($array, $field, $value){
 }
 
 
+/* Check if ports is open from the outside */
+function fullNodeCheck() {
+	$checks = array();
+	
+	$ch = curl_init();
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 
+	curl_setopt($ch, CURLOPT_DNS_CACHE_TIMEOUT, 0);
+	curl_setopt($ch, CURLOPT_URL, "https://guldennodes.com/portcheck/?json");
+	$openportcheck = curl_exec($ch);
+	
 
-
+	if ($openportcheck && $openportreturn = json_decode($openportcheck, true)) {
+		$checks[] = $openportreturn['success']?$openportreturn['success']:$openportreturn['error'];
+		$info = curl_getinfo($ch);		
+		curl_close($ch);
+		
+		if(filter_var($info['local_ip'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) { // check if ipv6 is used, if true do ipv4 check
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 
+			curl_setopt($ch, CURLOPT_DNS_CACHE_TIMEOUT, 0);
+			curl_setopt($ch, CURLOPT_URL, "https://guldennodes.com/portcheck/?json");
+			curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+			$openportcheck = curl_exec($ch);
+			if ($openportcheck && $openportreturn = json_decode($openportcheck, true)) {
+				$checks[] = $openportreturn['success']?$openportreturn['success']:$openportreturn['error'];
+			}
+			curl_close($ch);
+		}
+	} else {
+		$checks[] = 'Check failed';
+	}
+	
+	return $checks;
+}
 
 /* Gulden specific functions */
 


### PR DESCRIPTION
At the moment "full node port forward" check only checks ipv6 when it is available. I've added that is also checks ipv4.

I also sent the owner of guldennodes a message because the ipv6 checks always fails at the moment. 