### PR TITLE
fix importing witness accounts keys

### DIFF
--- a/ajax/witnessactions.php
+++ b/ajax/witnessactions.php
@@ -179,7 +179,7 @@ if(isset($_GET['action'])) {
 				if($guldenresponse!="-14") {
 					$accountnamechars = $_POST['importaccountname'];
 					$accountnamechars = str_replace(".", "_",$accountnamechars);
-					$importaccount = $gulden->importwitnesskeys($accountnamechars, $_POST['importaccountkey']);
+					$importaccount = $gulden->importwitnesskeys($accountnamechars, $_POST['importaccountkey'], true);
 					if($importaccount == false) {
 						$returnarray['code'] = $gulden->response['error']['code'];
 						$returnarray['message'] = $gulden->response['error']['message'];


### PR DESCRIPTION
Importing witness accounts does not work anymore, this needs a `true` as third param to tell that the account needs to be created instead of imported in current wallet.